### PR TITLE
Configures cdn distribution to produce more accurate ping and upload measurements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.tfstate.*
 build
 
+lambda_pkg
 secrets.tfvars
 .ipynb_checkpoints
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project experiments with setting up infrastructure (via `terraform`/`OpenTofu`) to serve a [speed test](https://github.com/openspeedtest/Speed-Test) via a CDN and collect the speed measurement data.
 
+This repo's speedtest is currently served [here](https://beadchallenge.net/).
+
 ## Prerequisites
 
 To follow these instructions, you will need to have:

--- a/infra/functions/post-request-ok.js
+++ b/infra/functions/post-request-ok.js
@@ -1,0 +1,12 @@
+function handler (event) {
+  const request = event.request;
+
+  if (request.method == 'POST') {
+    return {
+        statusCode: 204,
+        statusDescription: 'No Content'
+    };
+  }
+
+  return request;
+}

--- a/infra/functions/redirect-remove-www.js
+++ b/infra/functions/redirect-remove-www.js
@@ -1,0 +1,40 @@
+function handler (event) {
+    const host = event.request.headers.host.value;
+    
+    if (host.startsWith('www.')) {
+        const newHost = host.slice(4);
+        
+        const qstr = encodeRequestQuery(event.request.querystring);
+        const qpart = qstr === '' ? '' : `?${qstr}`;
+        
+        const location = `https://${newHost}${event.request.uri}${qpart}`;
+        
+        return {
+            statusCode: 301,
+            statusDescription: 'Moved Permanently',
+            headers: {
+                location: {value: location}
+            }
+        };
+    }
+    
+    return event.request;
+}
+
+function encodeRequestQuery (querystring) {
+    const parts = [];
+
+    for (const param in querystring) {
+        const query = querystring[param];
+        
+        if (query.multiValue) {
+            parts.push(query.multiValue.map((item) => param + '=' + item.value).join('&'));
+        } else if (query.value === '') {
+            parts.push(param);
+        } else {
+            parts.push(param + '=' + query.value);
+        }
+    }
+
+    return parts.join('&');
+}

--- a/license
+++ b/license
@@ -11,5 +11,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 This project incorporates code from the following MIT-licensed projects:
 
 * Speed-Test by OpenSpeedTest™
+* [speed.internetequity.org](https://github.com/internet-equity/speed.internetequity.org/tree/main) by the Internet Equity Initiative
 
 The full text of the MIT License applies to the portions of code derived from these projects.


### PR DESCRIPTION
Changes:
* Requires that HTTP/1.1 is used (rather than the default HTTP/2)
    * The test produced much more realistic upload measurements after this change.
* Configures different caching strategies for different kinds of files (including compressing assets and the index but not the upload file)
* Configures using [Origin Shield](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html) to add edge caches that ensures caches of the site are available at in-region AWS edges (thereby improving ping/latency).

closes #3 

![Screenshot 2024-09-16 at 3 36 49 PM](https://github.com/user-attachments/assets/b2cf8b18-798b-4f78-a452-11e98f9795b1)

![Screenshot 2024-09-16 at 3 35 15 PM](https://github.com/user-attachments/assets/5959c33c-6cff-4c2a-8586-c780eea8edf8)